### PR TITLE
API_HOST can now depend on the environment

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@ navigation:
   <script src="/js/lib/backgrid.js"></script>
   <script src="/js/lib/bootstrap.min.js"></script>
   <script>
-    var API_HOST = "http://datastore.transit.land";
+    var API_HOST = "{{site.api_host}}";
   </script>
  
 </head>

--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -1,0 +1,24 @@
+# Plugin to add environment variables to the `site` object in Liquid templates
+ 
+module Jekyll
+ 
+  class EnvironmentVariablesGenerator < Generator
+ 
+    def generate(site)
+      site.config['env'] = ENV['TARGET'] || 'dev'
+      # Add other environment variables to `site.config` here...
+      if site.config['env'] == 'prod'
+        site.config['url'] = '//playground.transit.land/'
+        site.config['api_host'] = '//datastore.transit.land'
+      elsif site.config['env'] == 'staging'
+        site.config['url'] = '//staging.playground.transit.land/'
+        site.config['api_host'] = '//datastore.transit.land/'
+      else
+        site.config['url'] = '/'
+        site.config['api_host'] = '//localhost:3000'
+      end
+    end
+ 
+  end
+ 
+end


### PR DESCRIPTION
- uses a local version of the Community Datastore when in `dev` mode (default)
- uses the hosted version of the Community Datastore when deployed to `staging` and `prod`
