### PR TITLE
Location lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,13 +31,11 @@ title: Playground
             <option> </option>
           </select>  
         </span>
-        :
         <span id="stateMenu" class="btn-group h2">
           <select class="form-control h2 s-text" id="state">
             <option> </option>
           </select>  
         </span>
-         :
         <span id="regionMenu" class="btn-group h2">
           <select class="form-control h2 s-text" id="region">
             <option> </option>

--- a/index.html
+++ b/index.html
@@ -26,16 +26,19 @@ title: Playground
 
     <p class="region-list white-text center-text">
       <span style="margin-left:10px" class="h2" id="region-line"> IN
+        <br>
          <span id="countryMenu" class="btn-group h2">
           <select class="form-control h2 s-text" id="country">
             <option> </option>
           </select>  
         </span>
+        <br>
         <span id="stateMenu" class="btn-group h2">
           <select class="form-control h2 s-text" id="state">
             <option> </option>
           </select>  
         </span>
+        <br>
         <span id="regionMenu" class="btn-group h2">
           <select class="form-control h2 s-text" id="region">
             <option> </option>

--- a/index.html
+++ b/index.html
@@ -25,14 +25,26 @@ title: Playground
     </p>
 
     <p class="region-list white-text center-text">
-      <span style="margin-left:10px" class="h2" id="region-line"> IN </span>
-      <span id="regionMenu" class="btn-group h2">
-        <select class="form-control h2 s-text" id="region">
-          <option> </option>
-        </select>  
+      <span style="margin-left:10px" class="h2" id="region-line"> IN
+         <span id="countryMenu" class="btn-group h2">
+          <select class="form-control h2 s-text" id="country">
+            <option> </option>
+          </select>  
+        </span>
+        :
+        <span id="stateMenu" class="btn-group h2">
+          <select class="form-control h2 s-text" id="state">
+            <option> </option>
+          </select>  
+        </span>
+         :
+        <span id="regionMenu" class="btn-group h2">
+          <select class="form-control h2 s-text" id="region">
+            <option> </option>
+          </select>  
+        </span>
       </span>
     </p>
-
     <div id="name-container" class="center-text">
       <span id="nameMenu" class="btn-group h2">
         <select class="form-control h2 s-text" id="name">
@@ -75,7 +87,15 @@ title: Playground
     <%= name %>
   </script>
 
-   <script type="text/template" id="region-template">
+  <script type="text/template" id="country-template">
+    <%= country %>
+  </script>
+
+  <script type="text/template" id="state-template">
+    <%= state %>
+  </script>
+
+  <script type="text/template" id="region-template">
     <%= metro %>
   </script>
  
@@ -118,8 +138,16 @@ title: Playground
   <script type="text/javascript" src="js/views/map.js" type="text/javascript"></script>
   <script type="text/javascript" src="js/views/name-list.js" type="text/javascript"></script>
   <script type="text/javascript" src="js/views/name.js" type="text/javascript"></script>
+ 
   <script type="text/javascript" src="js/views/region-list.js" type="text/javascript"></script>
   <script type="text/javascript" src="js/views/region.js" type="text/javascript"></script>
+
+  <script type="text/javascript" src="js/views/state-list.js" type="text/javascript"></script>
+  <script type="text/javascript" src="js/views/state.js" type="text/javascript"></script>
+
+  <script type="text/javascript" src="js/views/country-list.js" type="text/javascript"></script>
+  <script type="text/javascript" src="js/views/country.js" type="text/javascript"></script>
+  
   <script type="text/javascript" src="js/views/grid.js" type="text/javascript"></script>
   <script type="text/javascript" src="js/lib/backbone-dotattr.js"></script>
   <script type="text/javascript" src="js/lib/FileSaver.js"></script>

--- a/js/views/country-list.js
+++ b/js/views/country-list.js
@@ -8,7 +8,6 @@ DeveloperPlayground.CountryListView = Backbone.View.extend({
         this.close();
         this.collection = options.collection;
         this.countryViews = [];
-        // $('.form-control#region', this.$el).prepend("<option>region (optional)</option>");
         
         this.listenTo(this.collection, 'add', this.renderCountry);
         this.collection.each(this.renderCountry, this);

--- a/js/views/country-list.js
+++ b/js/views/country-list.js
@@ -1,0 +1,40 @@
+var DeveloperPlayground = DeveloperPlayground || {};
+
+DeveloperPlayground.CountryListView = Backbone.View.extend({
+	el: '.btn-group#countryMenu',
+
+   
+	initialize:function(options){
+        this.close();
+        this.collection = options.collection;
+        this.countryViews = [];
+        // $('.form-control#region', this.$el).prepend("<option>region (optional)</option>");
+        
+        this.listenTo(this.collection, 'add', this.renderCountry);
+        this.collection.each(this.renderCountry, this);
+    },
+
+    renderCountry: function(model) {
+        var countryView = new DeveloperPlayground.CountryView({
+            model: model
+        });        
+        if (!_.contains(this.countryViews, model.get('country'))){
+            this.countryViews.push(model.get('country'));
+            $(".form-control#country", this.$el).append(countryView.render().$el);
+        }
+
+    },
+
+    selectCountry: function(model) {
+		this.$el.val();
+		return this;
+    },
+
+    close: function() {
+        $('.form-control#country', this.$el).empty();
+        $('.form-control#country', this.$el).prepend("<option> </option>");
+        this.stopListening();
+        return this;
+    }
+
+});

--- a/js/views/country.js
+++ b/js/views/country.js
@@ -1,0 +1,16 @@
+var DeveloperPlayground = DeveloperPlayground || {};
+
+DeveloperPlayground.CountryView = Backbone.View.extend({
+	tagName: 'option',
+	template: _.template( $('#country-template').html() ),
+
+	render: function() {
+		this.$el.get('country');
+		renderedHtml = this.template(this.model.toJSON());
+		this.$el.html(renderedHtml);
+		this.$el.val(this.model.get('country'));
+		this.$el.text(this.model.get('country'));
+		return this;
+	},
+
+ });

--- a/js/views/map.js
+++ b/js/views/map.js
@@ -34,18 +34,7 @@ DeveloperPlayground.MapView = Backbone.View.extend({
             attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
         })
         .addTo(this.map);
-        $(".btn#san-francisco").addClass("selected");
         return this;
-    },
-
-    setMapviewSF: function() {
-        this.map.panTo(new L.LatLng(37.749, -122.443));
-        // ga('send', 'event', 'location toggle', 'click', 'SF');
-    },
-
-    setMapviewNY: function() {
-        this.map.panTo(new L.LatLng(40.7127, -74.0059));
-        // ga('send', 'event', 'location toggle', 'click', 'NY');
     },
 
     getBounds: function() {

--- a/js/views/name-list.js
+++ b/js/views/name-list.js
@@ -14,9 +14,18 @@ DeveloperPlayground.NameListView = Backbone.View.extend({
             model: model
         });
         var $regionSelect = $('select.form-control#region');
+        var $stateSelect = $('select.form-control#state');
+        var $countrySelect = $('select.form-control#country');
+        var $parameterSelect = $('select.form-control#parameter');
+       
 
-        // use region selection to render list of operator names
-        if (model.get('metro') === $regionSelect.val()){
+        if (($countrySelect.val() === '' || $countrySelect.val() === 'undefined' ) && ($parameterSelect.val() == "name" || $parameterSelect.val() == "operator")) {
+            $(".form-control#name", this.$el).append(nameView.render().$el);
+        } else if (($stateSelect.val() === '' || $stateSelect.val() === 'undefined' ) && (model.get('country') === $countrySelect.val())){
+            $(".form-control#name", this.$el).append(nameView.render().$el);
+        } else if (($regionSelect.val() === '' || $regionSelect.val() === 'undefined' ) && (model.get('state') === $stateSelect.val())){
+            $(".form-control#name", this.$el).append(nameView.render().$el);
+        } else if (model.get('metro') === $regionSelect.val()){
             $(".form-control#name", this.$el).append(nameView.render().$el);
         }
 

--- a/js/views/region-list.js
+++ b/js/views/region-list.js
@@ -19,7 +19,6 @@ DeveloperPlayground.RegionListView = Backbone.View.extend({
             model: model
         });
         
-        // if ((!_.contains(this.regionViews, model.get('metro'))) && (this.get('metro') === countrySelect)){
         if ((!_.contains(this.regionViews, model.get('metro'))) && (model.get('state') === $stateSelect)){
             this.regionViews.push(model.get('metro'));
             $(".form-control#region", this.$el).append(regionView.render().$el);

--- a/js/views/region-list.js
+++ b/js/views/region-list.js
@@ -12,11 +12,15 @@ DeveloperPlayground.RegionListView = Backbone.View.extend({
     },
 
     renderRegion: function(model) {
+
+        var $stateSelect = $('select.form-control#state').val();
+
         var regionView = new DeveloperPlayground.RegionView({
             model: model
         });
         
-        if (!_.contains(this.regionViews, model.get('metro'))){
+        // if ((!_.contains(this.regionViews, model.get('metro'))) && (this.get('metro') === countrySelect)){
+        if ((!_.contains(this.regionViews, model.get('metro'))) && (model.get('state') === $stateSelect)){
             this.regionViews.push(model.get('metro'));
             $(".form-control#region", this.$el).append(regionView.render().$el);
         }

--- a/js/views/region.js
+++ b/js/views/region.js
@@ -9,7 +9,7 @@ DeveloperPlayground.RegionView = Backbone.View.extend({
 		renderedHtml = this.template(this.model.toJSON());
 		this.$el.html(renderedHtml);
 		this.$el.val(this.model.get('metro'));
-		this.$el.text(this.model.get('country') + ", " + this.model.get('state') + ", " + this.model.get('metro'));
+		this.$el.text(this.model.get('metro'));
 		return this;
 	},
 

--- a/js/views/start-query-builder.js
+++ b/js/views/start-query-builder.js
@@ -100,15 +100,25 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
             collection = this.operators;
             $("#region-line").show();
             $("#countryMenu").show();
+            $("#nameMenu").show();
 
 
             if(!$("#countryMenu").hasClass("dropdown")) $("#countryMenu").addClass("dropdown");
+            if(!$("#nameMenu").hasClass("dropdown")) $("#nameMenu").addClass("dropdown");
+
 
             if ('undefined' !== typeof this.countryListView) {
                 this.countryListView.close();
                 this.countryListView = new DeveloperPlayground.CountryListView({collection: collection});
             } else {
                 this.countryListView = new DeveloperPlayground.CountryListView({collection: collection});
+            }
+
+            if ('undefined' !== typeof this.nameListView) {
+                this.nameListView.close();
+                this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
+            } else {
+                this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
             }
 
             this.operators.setQueryParameters({
@@ -136,14 +146,16 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
     changeCountry: function() {
         var $countrySelect = $('select.form-control#country');
         $("#regionMenu").hide();
-        if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
 
+        if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
+        if(!$("#nameMenu").hasClass("dropdown")) $("#nameMenu").addClass("dropdown");
 
 
         if ($countrySelect.val() !== 'undefined') {
             collection = this.operators;
             $("#stateMenu").show();
-            
+            $("#nameMenu").show();
+
             if(!$("#stateMenu").hasClass("dropdown")) $("#stateMenu").addClass("dropdown");
             
             if ('undefined' !== typeof this.stateListView) {
@@ -151,6 +163,13 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
                 this.stateListView = new DeveloperPlayground.StateListView({collection: collection});
             } else {
                 this.stateListView = new DeveloperPlayground.StateListView({collection: collection});
+            }
+
+            if ('undefined' !== typeof this.nameListView) {
+                this.nameListView.close();
+                this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
+            } else {
+                this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
             }
 
             this.operators.setQueryParameters({
@@ -171,14 +190,26 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
         if ($stateSelect.val() !== 'undefined') {
             collection = this.operators;
             $("#regionMenu").show();
+            $("#nameMenu").show();
+
             
             if(!$("#regionMenu").hasClass("dropdown")) $("#regionMenu").addClass("dropdown");
+            if(!$("#nameMenu").hasClass("dropdown")) $("#nameMenu").addClass("dropdown");
+
             if ('undefined' !== typeof this.regionListView) {
                 this.regionListView.close();
                 this.regionListView = new DeveloperPlayground.RegionListView({collection: collection});
             } else {
                 this.regionListView = new DeveloperPlayground.RegionListView({collection: collection});
             }
+
+            if ('undefined' !== typeof this.nameListView) {
+                this.nameListView.close();
+                this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
+            } else {
+                this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
+            }
+
             this.operators.setQueryParameters({
                     url: API_HOST+'/api/v1/operators.json?per_page=5000'
                 });
@@ -187,7 +218,6 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
 
         } else {
             $("#regionMenu").hide();
-
             if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
 
         }
@@ -198,9 +228,10 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
 
         if ($regionSelect.val() !== 'undefined') {
             collection = this.operators;
-            $("#nameMenu").show();
+            // $("#nameMenu").show();
             
             if(!$("#nameMenu").hasClass("dropdown")) $("#nameMenu").addClass("dropdown");
+            
             if ('undefined' !== typeof this.nameListView) {
                 this.nameListView.close();
                 this.nameListView = new DeveloperPlayground.NameListView({collection: collection});

--- a/js/views/start-query-builder.js
+++ b/js/views/start-query-builder.js
@@ -179,6 +179,8 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
             return this;
 
         } else {
+            this.nameListView.close();
+            this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
             $("#stateMenu").hide();
             if($("#stateMenu").hasClass("dropdown")) $("#stateMenu").removeClass("dropdown");
         }
@@ -215,11 +217,11 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
                 });
             collection.fetch();
             return this;
-
         } else {
+            this.nameListView.close();
+            this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
             $("#regionMenu").hide();
             if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
-
         }
     },
 
@@ -244,9 +246,10 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
             return this;
 
         } else {
+            this.nameListView.close();
+            this.nameListView = new DeveloperPlayground.NameListView({collection: collection});
             $("#nameMenu").hide();
             if($("#nameMenu").hasClass("dropdown")) $("#nameMenu").removeClass("dropdown");
-
         }
     },
 

--- a/js/views/start-query-builder.js
+++ b/js/views/start-query-builder.js
@@ -151,7 +151,7 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
         if(!$("#nameMenu").hasClass("dropdown")) $("#nameMenu").addClass("dropdown");
 
 
-        if ($countrySelect.val() !== 'undefined') {
+        if (($countrySelect.val() !== 'undefined') && ($countrySelect.val() !== '') ) {
             collection = this.operators;
             $("#stateMenu").show();
             $("#nameMenu").show();
@@ -187,7 +187,7 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
     changeState: function() {
         var $stateSelect = $('select.form-control#state');
 
-        if ($stateSelect.val() !== 'undefined') {
+        if (($stateSelect.val() !== 'undefined') && ($stateSelect.val() !== ''))  {
             collection = this.operators;
             $("#regionMenu").show();
             $("#nameMenu").show();

--- a/js/views/start-query-builder.js
+++ b/js/views/start-query-builder.js
@@ -9,6 +9,8 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
     events: {
         'change .form-control#entity': 'changeParam',
         'change .form-control#parameter': 'changeFilter',
+        'change .form-control#country': 'changeCountry',
+        'change .form-control#state': 'changeState',
         'change .form-control#region': 'changeRegion',
         'click .btn#run-query-btn' : 'submit',
     },
@@ -23,12 +25,16 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
     render: function() {
         this.$el.html(this.template());
         $("#nameMenu").hide();
+        $("#countryMenu").hide();
+        $("#stateMenu").hide();
         $("#regionMenu").hide();
         $("#region-line").hide();
 
 
         if($("#nameMenu").hasClass("dropdown")) $("#nameMenu").removeClass("dropdown");
         if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
+        if($("#stateMenu").hasClass("dropdown")) $("#stateMenu").removeClass("dropdown");
+        if($("#countryMenu").hasClass("dropdown")) $("#countryMenu").removeClass("dropdown");
         this.mapview = new DeveloperPlayground.MapView();
         this.mapview.render();
         this.downloadview = new DeveloperPlayground.DownloadView();
@@ -39,11 +45,14 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
     changeParam: function() {
 
         $("#nameMenu").hide();
+        $("#countryMenu").hide();
+        $("#stateMenu").hide();
         $("#regionMenu").hide();
         $("#region-line").hide();
 
         if($("#nameMenu").hasClass("dropdown")) $("#nameMenu").removeClass("dropdown");
         if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
+        if($("#countryMenu").hasClass("dropdown")) $("#countryMenu").removeClass("dropdown");
 
         var $entitySelect = $('select.form-control#entity');
         var $parameterSelect = $('select.form-control#parameter');
@@ -83,16 +92,86 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
     
     changeFilter: function() {
         var $parameterSelect = $('select.form-control#parameter');
-        $('.form-control#region', this.$el).empty();
-        $('.form-control#region', this.$el).prepend("<option> </option>");
+        $('.form-control#country', this.$el).empty();
 
         // If the filter (name/mapview) is changed to name/operator, show the region line/menu
 
         if($parameterSelect.val() == "name" || $parameterSelect.val() == "operator") {
             collection = this.operators;
-            $("#regionMenu").show();
             $("#region-line").show();
+            $("#countryMenu").show();
 
+
+            if(!$("#countryMenu").hasClass("dropdown")) $("#countryMenu").addClass("dropdown");
+
+            if ('undefined' !== typeof this.countryListView) {
+                this.countryListView.close();
+                this.countryListView = new DeveloperPlayground.CountryListView({collection: collection});
+            } else {
+                this.countryListView = new DeveloperPlayground.CountryListView({collection: collection});
+            }
+
+            this.operators.setQueryParameters({
+            url: API_HOST+'/api/v1/operators.json?per_page=5000'
+                });
+            collection.fetch();
+
+            return this;
+
+        } else {
+            $("#region-line").hide();
+            $("#countryMenu").hide();
+            $("#stateMenu").hide();
+            $("#regionMenu").hide();
+            $("#nameMenu").hide();
+
+            if($("#countryMenu").hasClass("dropdown")) $("#countryMenu").removeClass("dropdown");
+            if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
+            if($("#stateMenu").hasClass("dropdown")) $("#stateMenu").removeClass("dropdown");
+            if($("#nameMenu").hasClass("dropdown")) $("#nameMenu").removeClass("dropdown");
+
+        }
+    },
+
+    changeCountry: function() {
+        var $countrySelect = $('select.form-control#country');
+        $("#regionMenu").hide();
+        if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
+
+
+
+        if ($countrySelect.val() !== 'undefined') {
+            collection = this.operators;
+            $("#stateMenu").show();
+            
+            if(!$("#stateMenu").hasClass("dropdown")) $("#stateMenu").addClass("dropdown");
+            
+            if ('undefined' !== typeof this.stateListView) {
+                this.stateListView.close();
+                this.stateListView = new DeveloperPlayground.StateListView({collection: collection});
+            } else {
+                this.stateListView = new DeveloperPlayground.StateListView({collection: collection});
+            }
+
+            this.operators.setQueryParameters({
+                    url: API_HOST+'/api/v1/operators.json?per_page=5000'
+                });
+            collection.fetch();
+            return this;
+
+        } else {
+            $("#stateMenu").hide();
+            if($("#stateMenu").hasClass("dropdown")) $("#stateMenu").removeClass("dropdown");
+        }
+    },
+
+    changeState: function() {
+        var $stateSelect = $('select.form-control#state');
+
+        if ($stateSelect.val() !== 'undefined') {
+            collection = this.operators;
+            $("#regionMenu").show();
+            
             if(!$("#regionMenu").hasClass("dropdown")) $("#regionMenu").addClass("dropdown");
             if ('undefined' !== typeof this.regionListView) {
                 this.regionListView.close();
@@ -107,12 +186,9 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
             return this;
 
         } else {
-            $("#region-line").hide();
             $("#regionMenu").hide();
-            $("#nameMenu").hide();
 
             if($("#regionMenu").hasClass("dropdown")) $("#regionMenu").removeClass("dropdown");
-            if($("#nameMenu").hasClass("dropdown")) $("#nameMenu").removeClass("dropdown");
 
         }
     },
@@ -139,7 +215,6 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
 
         } else {
             $("#nameMenu").hide();
-
             if($("#nameMenu").hasClass("dropdown")) $("#nameMenu").removeClass("dropdown");
 
         }

--- a/js/views/start-query-builder.js
+++ b/js/views/start-query-builder.js
@@ -228,7 +228,6 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
 
         if ($regionSelect.val() !== 'undefined') {
             collection = this.operators;
-            // $("#nameMenu").show();
             
             if(!$("#nameMenu").hasClass("dropdown")) $("#nameMenu").addClass("dropdown");
             

--- a/js/views/start-query-builder.js
+++ b/js/views/start-query-builder.js
@@ -10,8 +10,6 @@ DeveloperPlayground.StartQueryBuilderView = Backbone.View.extend({
         'change .form-control#entity': 'changeParam',
         'change .form-control#parameter': 'changeFilter',
         'change .form-control#region': 'changeRegion',
-        'click .btn#san-francisco': 'changeMapSF',
-        'click .btn#new-york': 'changeMapNY',
         'click .btn#run-query-btn' : 'submit',
     },
 

--- a/js/views/state-list.js
+++ b/js/views/state-list.js
@@ -1,0 +1,47 @@
+var DeveloperPlayground = DeveloperPlayground || {};
+
+DeveloperPlayground.StateListView = Backbone.View.extend({
+	el: '.btn-group#stateMenu',
+
+   
+	initialize:function(options){
+        this.close();
+        this.collection = options.collection;
+        this.stateViews = [];
+        // $('.form-control#region', this.$el).prepend("<option>region (optional)</option>");
+        
+        this.listenTo(this.collection, 'add', this.renderState);
+        this.collection.each(this.renderState, this);
+    },
+
+    renderState: function(model) {
+        var $countrySelect = $('select.form-control#country').val();
+
+        var stateView = new DeveloperPlayground.StateView({
+            model: model
+        });
+        // if (!_.contains(this.stateViews, model.get('state'))){
+        //     this.stateViews.push(model.get('state'));
+        //     $(".form-control#state", this.$el).append(stateView.render().$el);
+        // }
+
+        if ((!_.contains(this.stateViews, model.get('state'))) && (model.get('country') === $countrySelect)){
+            this.stateViews.push(model.get('state'));
+            $(".form-control#state", this.$el).append(stateView.render().$el);
+        }
+
+    },
+
+    selectState: function(model) {
+		this.$el.val();
+		return this;
+    },
+
+    close: function() {
+        $('.form-control#state', this.$el).empty();
+        $('.form-control#state', this.$el).prepend("<option> </option>");
+        this.stopListening();
+        return this;
+    }
+
+});

--- a/js/views/state-list.js
+++ b/js/views/state-list.js
@@ -8,7 +8,6 @@ DeveloperPlayground.StateListView = Backbone.View.extend({
         this.close();
         this.collection = options.collection;
         this.stateViews = [];
-        // $('.form-control#region', this.$el).prepend("<option>region (optional)</option>");
         
         this.listenTo(this.collection, 'add', this.renderState);
         this.collection.each(this.renderState, this);
@@ -20,11 +19,7 @@ DeveloperPlayground.StateListView = Backbone.View.extend({
         var stateView = new DeveloperPlayground.StateView({
             model: model
         });
-        // if (!_.contains(this.stateViews, model.get('state'))){
-        //     this.stateViews.push(model.get('state'));
-        //     $(".form-control#state", this.$el).append(stateView.render().$el);
-        // }
-
+     
         if ((!_.contains(this.stateViews, model.get('state'))) && (model.get('country') === $countrySelect)){
             this.stateViews.push(model.get('state'));
             $(".form-control#state", this.$el).append(stateView.render().$el);

--- a/js/views/state.js
+++ b/js/views/state.js
@@ -1,0 +1,16 @@
+var DeveloperPlayground = DeveloperPlayground || {};
+
+DeveloperPlayground.StateView = Backbone.View.extend({
+	tagName: 'option',
+	template: _.template( $('#state-template').html() ),
+
+	render: function() {
+		this.$el.get('state');
+		renderedHtml = this.template(this.model.toJSON());
+		this.$el.html(renderedHtml);
+		this.$el.val(this.model.get('state'));
+		this.$el.text(this.model.get('state'));
+		return this;
+	},
+
+ });


### PR DESCRIPTION
This PR adds a finer-grain to the process of filtering operator names by location, creating separate menus for country, state, and region. The operator name list will first show all available operator names (before any location filter has been applied). Selecting a country will narrow the list of operator names, as will selecting a state and a region.

It also removes references to a SF/NYC map toggle that is no longer rendered.

Resolves https://github.com/transitland/feed-registry/issues/280
